### PR TITLE
Test suite for Orma (v0.6.0)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         applicationId "net.pside.android.example.mostpowerfulorminandroid"
-        minSdkVersion 9
+        minSdkVersion 15
         targetSdkVersion 23
         versionCode 2
         versionName "2015.1"
@@ -127,9 +127,10 @@ dependencies {
     squidbCompile 'com.yahoo.squidb:squidb-annotations:2.0.1'
 
     // Orma
-    apt 'com.github.gfx.android.orma:orma-processor:0.0.1'
-    ormaProvided 'com.github.gfx.android.orma:orma-annotations:0.0.1'
-    ormaCompile 'com.github.gfx.android.orma:orma:0.0.1'
+    apt 'com.github.gfx.android.orma:orma-processor:0.5.0'
+    ormaProvided 'com.github.gfx.android.orma:orma-annotations:0.5.0'
+    ormaProvided 'javax.annotation:jsr250-api:1.0'
+    ormaCompile 'com.github.gfx.android.orma:orma:0.5.0'
 
     // EasyliteORM
     compile 'com.easyliteorm:easyliteorm:1.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,10 +127,8 @@ dependencies {
     squidbCompile 'com.yahoo.squidb:squidb-annotations:2.0.1'
 
     // Orma
-    apt 'com.github.gfx.android.orma:orma-processor:0.5.0'
-    ormaProvided 'com.github.gfx.android.orma:orma-annotations:0.5.0'
-    ormaProvided 'javax.annotation:jsr250-api:1.0'
-    ormaCompile 'com.github.gfx.android.orma:orma:0.5.0'
+    apt 'com.github.gfx.android.orma:orma-processor:0.6.0'
+    ormaCompile 'com.github.gfx.android.orma:orma:0.6.0'
 
     // EasyliteORM
     compile 'com.easyliteorm:easyliteorm:1.2.0'

--- a/app/src/androidTestOrma/java/net/pside/android/example/mostpowerfulorminandroid/OrmaTest.java
+++ b/app/src/androidTestOrma/java/net/pside/android/example/mostpowerfulorminandroid/OrmaTest.java
@@ -1,0 +1,89 @@
+package net.pside.android.example.mostpowerfulorminandroid;
+
+import com.github.gfx.android.orma.Inserter;
+import com.github.gfx.android.orma.TransactionTask;
+import com.github.gfx.android.orma.adapter.TypeAdapterRegistry;
+
+import net.pside.android.example.mostpowerfulorminandroid.model.OrmaDatabase;
+import net.pside.android.example.mostpowerfulorminandroid.model.Simple;
+import net.pside.android.example.mostpowerfulorminandroid.util.TimingLogger;
+
+import android.support.annotation.NonNull;
+
+import java.util.Date;
+import java.util.List;
+
+public class OrmaTest extends OrmTestCase {
+    public static final String TAG = OrmaTest.class.getSimpleName();
+
+    OrmaDatabase db;
+
+    @NonNull
+    @Override
+    protected String getDatabaseName() {
+        return "orma.db";
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        db = new OrmaDatabase(getContext(), getDatabaseName());
+        db.addTypeAdapters(TypeAdapterRegistry.defaultTypeAdapters());
+        db.getConnection().resetDatabase();
+    }
+
+    @Override
+    public void testSingleInsert() {
+        insert(false);
+    }
+
+    @Override
+    public void testSingleBulkInsert() {
+        insert(true);
+    }
+
+    public void insert(boolean isBulkMode) {
+        TimingLogger logger = new TimingLogger(TAG, MSG_LOGGER_INITIALIZE(isBulkMode));
+
+        if (isBulkMode) {
+            db.transaction(new TransactionTask() {
+                @Override
+                public void execute() throws Exception {
+                    Inserter<Simple> inserter = db.prepareInsertIntoSimple();
+                    for (int i = 1; i <= IOrmTestCase.NUMBER_OF_INSERT_SINGLE; i++) {
+                        inserter.execute(createSimple(i));
+                    }
+                }
+            });
+        } else {
+            for (int i = 1; i <= IOrmTestCase.NUMBER_OF_INSERT_SINGLE; i++) {
+                db.insertIntoSimple(createSimple(i));
+            }
+        }
+
+        logger.addSplit(MSG_LOGGER_SPLIT_INSERT);
+
+        List<Simple> simpleList = db.selectFromSimple()
+                .where("booleanValue = ?", true)
+                .toList();
+
+        assertEquals(NUMBER_OF_INSERT_SINGLE / 2, simpleList.size());
+
+        logger.addSplit(MSG_LOGGER_SPLIT_SELECT);
+        logger.dumpToLog();
+    }
+
+    private Simple createSimple(int i) {
+        Simple simple = new Simple();
+        simple.stringValue = "TestData" + i;
+        simple.dateValue = new Date(i * 1000);
+        simple.booleanValue = (i % 2 == 0);
+        simple.shortValue = (short) i;
+        simple.intValue = i;
+        simple.longValue = i;
+        simple.floatValue = i;
+        simple.doubleValue = i;
+        return simple;
+    }
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildFive.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildFive.java
@@ -1,0 +1,12 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ChildFive {
+
+    @Column
+    public String ormName;
+
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildFour.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildFour.java
@@ -1,0 +1,11 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ChildFour {
+
+    @Column
+    public ChildFive childFive;
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildOne.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildOne.java
@@ -1,0 +1,11 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ChildOne {
+
+    @Column
+    public ChildTwo childTwo;
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildThree.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildThree.java
@@ -1,0 +1,11 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ChildThree {
+
+    @Column
+    public ChildFour childFour;
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildTwo.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/ChildTwo.java
@@ -1,0 +1,11 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class ChildTwo {
+
+    @Column
+    public ChildThree childThree;
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/Parent.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/Parent.java
@@ -1,0 +1,11 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+@Table
+public class Parent {
+
+    @Column
+    public ChildOne childOne;
+}

--- a/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/Simple.java
+++ b/app/src/orma/java/net/pside/android/example/mostpowerfulorminandroid/model/Simple.java
@@ -1,0 +1,37 @@
+package net.pside.android.example.mostpowerfulorminandroid.model;
+
+import com.github.gfx.android.orma.annotation.Column;
+import com.github.gfx.android.orma.annotation.Table;
+
+import java.util.Date;
+
+@Table
+public class Simple {
+
+    @Column
+    public long id;
+
+    @Column
+    public String stringValue;
+
+    @Column
+    public Date dateValue;
+
+    @Column
+    public boolean booleanValue;
+
+    @Column
+    public short shortValue;
+
+    @Column
+    public int intValue;
+
+    @Column
+    public long longValue;
+
+    @Column
+    public float floatValue;
+
+    @Column
+    public double doubleValue;
+}


### PR DESCRIPTION
[Orma](https://github.com/gfx/Android-Orma) を追加しました。

OrmaTest.java が妥当かどうかご確認ください。

なお手元のNexus 9 (Marshmallow) で2回実行すると↓のようになりました。

```shell
adb logcat -t 1000 | ag OrmaTest: | perl -p -E 's/^.*OrmaTest: //'
```

```
Insert on ORMA (BulkMode:ON): begin
Insert on ORMA (BulkMode:ON):      270 ms, Insert 10000 records.
Insert on ORMA (BulkMode:ON):      48 ms, Select Records.
Insert on ORMA (BulkMode:ON): end, 318 ms
Insert on ORMA (BulkMode:OFF): begin
Insert on ORMA (BulkMode:OFF):      8440 ms, Insert 10000 records.
Insert on ORMA (BulkMode:OFF):      42 ms, Select Records.
Insert on ORMA (BulkMode:OFF): end, 8482 ms
Insert on ORMA (BulkMode:ON): begin
Insert on ORMA (BulkMode:ON):      255 ms, Insert 10000 records.
Insert on ORMA (BulkMode:ON):      42 ms, Select Records.
Insert on ORMA (BulkMode:ON): end, 297 ms
Insert on ORMA (BulkMode:OFF): begin
Insert on ORMA (BulkMode:OFF):      11062 ms, Insert 10000 records.
Insert on ORMA (BulkMode:OFF):      40 ms, Select Records.
Insert on ORMA (BulkMode:OFF): end, 11102 ms
```

同じ端末でのRealm (v0.84.2)の結果は↓です。

```shell
adb logcat -t 1000 | ag RealmTest: | perl -p -E 's/^.*RealmTest: //'
```

```
Insert on REALM (BulkMode:ON): begin
Insert on REALM (BulkMode:ON):      346 ms, Insert 10000 records.
Insert on REALM (BulkMode:ON):      4 ms, Select Records.
Insert on REALM (BulkMode:ON):      38 ms, Manual Import!: Select Records.
Insert on REALM (BulkMode:ON): end, 388 ms
Insert on REALM (BulkMode:OFF): begin
Insert on REALM (BulkMode:OFF):      56026 ms, Insert 10000 records.
Insert on REALM (BulkMode:OFF):      3 ms, Select Records.
Insert on REALM (BulkMode:OFF):      30 ms, Manual Import!: Select Records.
Insert on REALM (BulkMode:OFF): end, 56059 ms
Insert on REALM (BulkMode:ON): begin
Insert on REALM (BulkMode:ON):      318 ms, Insert 10000 records.
Insert on REALM (BulkMode:ON):      2 ms, Select Records.
Insert on REALM (BulkMode:ON):      31 ms, Manual Import!: Select Records.
Insert on REALM (BulkMode:ON): end, 351 ms
Insert on REALM (BulkMode:OFF): begin
Insert on REALM (BulkMode:OFF):      57327 ms, Insert 10000 records.
Insert on REALM (BulkMode:OFF):      1 ms, Select Records.
Insert on REALM (BulkMode:OFF):      27 ms, Manual Import!: Select Records.
Insert on REALM (BulkMode:OFF): end, 57355 ms
```

ところで、Realmは `findAll() -> RealmResults<T>` を行った時点ではクエリを発行しないようです。RealmResultsから値を取り出そうとして初めてクエリを発行するようですね。なので、manual importまでしてはじめて等価のオペレーションといってよさそうです。

Realmが爆速といわれるのは案外ベンチマークコードの間違いで、現状（v0.8x）だと最適化されたSQLiteベースのORMと実は大差ないという可能性がありますね。